### PR TITLE
Resolve four-word bootstrap seeds in communitas-headless

### DIFF
--- a/communitas-headless/Cargo.toml
+++ b/communitas-headless/Cargo.toml
@@ -20,6 +20,7 @@ communitas-container = { path = "../crates/communitas-container" }
 # Networking
 ant-quic = "0.8"
 saorsa-core = "=0.3.21"
+four-word-networking = "2.6"
 
 # CLI
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION
## Summary
- add the four-word-networking dependency to communitas-headless so four-word seeds can be decoded
- decode and normalise four-word bootstrap entries, deduplicating resolved peers and improving logging before connecting

## Testing
- cargo fmt --all
- cargo clippy --all-features -- -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
- cargo test -p communitas-headless

------
https://chatgpt.com/codex/tasks/task_e_68cae761d1e0832da05f260aeb2d8774