### PR TITLE
Propagate bootstrap config to testnet nodes

### DIFF
--- a/cloud-init.yml
+++ b/cloud-init.yml
@@ -70,7 +70,7 @@ runcmd:
     User=root
     EnvironmentFile=/etc/communitas-port.env
     Environment=RUST_LOG=info,communitas=debug,saorsa_core=info
-    ExecStart=/opt/communitas/bin/communitas-headless --listen 0.0.0.0:${COMMUNITAS_QUIC_PORT} --metrics --metrics-addr 127.0.0.1:9600
+    ExecStart=/opt/communitas/bin/communitas-headless --config /etc/communitas/config.toml --listen 0.0.0.0:${COMMUNITAS_QUIC_PORT} --metrics --metrics-addr 127.0.0.1:9600
     Restart=always
     RestartSec=5
     LimitNOFILE=1048576

--- a/deployment/systemd/communitas.service
+++ b/deployment/systemd/communitas.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 User=communitas
 EnvironmentFile=-/etc/communitas-port.env
 Environment=RUST_LOG=info,communitas=debug,saorsa_core=info
-ExecStart=/opt/communitas/bin/communitas-headless --listen 0.0.0.0:${COMMUNITAS_QUIC_PORT} --metrics --metrics-addr 0.0.0.0:9600
+ExecStart=/opt/communitas/bin/communitas-headless --config /etc/communitas/config.toml --listen 0.0.0.0:${COMMUNITAS_QUIC_PORT} --metrics --metrics-addr 0.0.0.0:9600
 Restart=always
 RestartSec=5
 LimitNOFILE=1048576


### PR DESCRIPTION
## Summary
- update the deploy-testnet script to build a communitas config that mirrors the generated bootstrap list
- push the generated config to each droplet and restart the systemd unit so the refreshed seeds are loaded
- ensure both the packaged systemd unit and cloud-init template pass --config /etc/communitas/config.toml to communitas-headless

## Testing
- not run (deployment script updates only)


------
https://chatgpt.com/codex/tasks/task_e_68cae75bc014832d8fcfd6c364a4f52c